### PR TITLE
Add AL evaluation/benchmark papers (NeurIPS 2023, TMLR 2025, TMLR 2026)

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,9 @@ There have been several reviews / surveys / benchmarks for this topic.
 - [A Framework and Benchmark for Deep Batch Active Learning for Regression [2022]](https://arxiv.org/pdf/2203.09410.pdf)
 - [Re-Benchmarking Pool-Based Active Learning for Binary Classification [2023]](https://arxiv.org/pdf/2306.08954.pdf)
 - [LabelBench: A Comprehensive Framework for Benchmarking Label-Efficient Learning [2023]](https://arxiv.org/pdf/2306.09910.pdf)
+- [Navigating the Pitfalls of Active Learning Evaluation: A Systematic Framework for Meaningful Performance Assessment [2023, NeurIPS]](https://proceedings.neurips.cc/paper_files/paper/2023/hash/1ed4723f12853cbd02aecb8160f5e0c9-Abstract-Conference.html)
+- [nnActive: A Framework for Evaluation of Active Learning in 3D Biomedical Segmentation [2025, TMLR]](https://openreview.net/forum?id=AJAnmRLJjJ) [[Code]](https://github.com/MIC-DKFZ/nnActive) [[Results]](https://huggingface.co/nnActive)
+- [Finally Outshining the Random Baseline: A Simple and Effective Solution for Active Learning in 3D Biomedical Imaging [2026, TMLR]](https://arxiv.org/abs/2601.13677) [[Code]](https://github.com/MIC-DKFZ/nnActive) [[Results]](https://huggingface.co/nnActive)
 
 ### **Tutorials - 教程**
 

--- a/conference/NeuraIPS.md
+++ b/conference/NeuraIPS.md
@@ -1,4 +1,5 @@
 ## Main Conference
+- [Navigating the Pitfalls of Active Learning Evaluation: A Systematic Framework for Meaningful Performance Assessment [2023, NeurIPS]](https://proceedings.neurips.cc/paper_files/paper/2023/hash/1ed4723f12853cbd02aecb8160f5e0c9-Abstract-Conference.html) [[Code]](https://github.com/sten2lu/realistic-al): Identifies 5 AL evaluation pitfalls; large-scale empirical study across datasets, query methods, and training paradigms (incl. semi-supervised and self-supervised).
 - Interactive Multi-fidelity Learning for Cost-effective Adaptation of Language Model with Sparse Human Supervision [2023, NeurIPS]
 - Active Learning Helps Pretrained Models Learn the Intended Task [2022, NeuraIPS]
 - Batch Active Learning from the Perspective of Sparse Approximation [2022, NeurIPS]

--- a/contents/deep_AL_criticism.md
+++ b/contents/deep_AL_criticism.md
@@ -91,5 +91,23 @@ Present an AL benchmarking suite and run extensive experiments on five datasets 
 
 ## 8. How To Overcome Confirmation Bias in Semi-Supervised Image Classification By Active Learning [2023, ECML PKDD]
 
-Our experiments show that AL is a useful tool to overcome confirmation bias in various real-world challenges. 
+Our experiments show that AL is a useful tool to overcome confirmation bias in various real-world challenges.
 However, it is not trivial to determine which AL method is most suitable in a real-world scenario.
+
+## 9. Navigating the Pitfalls of Active Learning Evaluation: A Systematic Framework for Meaningful Performance Assessment [2023, NeurIPS]
+
+Identifies five systematic evaluation pitfalls in AL research.
+Large-scale benchmark: multiple datasets × query methods × training paradigms (incl. semi-supervised and self-supervised).
+Code: https://github.com/sten2lu/realistic-al
+
+## 10. nnActive: A Framework for Evaluation of Active Learning in 3D Biomedical Segmentation [2025, TMLR]
+
+Largest AL benchmark to date: ~150k GPU hours, 8 methods × 4 datasets × 3 label regimes.
+Addresses four critical evaluation pitfalls; proposes Foreground-Aware Random sampling and foreground efficiency metric.
+Code: https://github.com/MIC-DKFZ/nnActive · Results: https://huggingface.co/nnActive
+
+## 11. Finally Outshining the Random Baseline: A Simple and Effective Solution for Active Learning in 3D Biomedical Imaging [2026, TMLR]
+
+First AL method consistently outperforming random baseline in 3D biomedical segmentation.
+Practitioner deployment guidelines included.
+Code: https://github.com/MIC-DKFZ/nnActive · Results: https://huggingface.co/nnActive


### PR DESCRIPTION
Hi! Adding three papers on AL evaluation methodology:

1. **[NeurIPS 2023] Navigating the Pitfalls of AL Evaluation** — large-scale benchmark identifying 5 common evaluation flaws. Added to: NeuraIPS.md, Benchmarks section, deep_AL_criticism.md.

2. **[TMLR 2025] nnActive** — largest AL benchmark for 3D biomedical segmentation (~150k GPU hours, 8 methods × 4 datasets). Code: https://github.com/MIC-DKFZ/nnActive, Results: https://huggingface.co/nnActive. Added to: Benchmarks section, deep_AL_criticism.md.

3. **[TMLR 2026] Finally Outshining the Random Baseline** — simple effective AL solution consistently beating random in 3D medical imaging. Code: https://github.com/MIC-DKFZ/nnActive, Results: https://huggingface.co/nnActive. Added to: Benchmarks section, deep_AL_criticism.md.

Happy to adjust placement or format if needed.